### PR TITLE
Add invalid argument error code to wait_for_tx

### DIFF
--- a/src/client/send.rs
+++ b/src/client/send.rs
@@ -125,7 +125,7 @@ impl Contact {
                     }
                 }
                 Err(CosmosGrpcError::RequestError { error }) => match error.code() {
-                    TonicCode::NotFound | TonicCode::Unknown => {}
+                    TonicCode::NotFound | TonicCode::Unknown | TonicCode::InvalidArgument => {}
                     _ => {
                         return Err(CosmosGrpcError::TransactionFailed {
                             tx: response,


### PR DESCRIPTION
Cosmos SDK returns an invalid argument error when querying a tx that doesn’t exist for some reason. This causes the Orchestrator to not return keys during setup.