### PR TITLE
Add support for viewing vesting info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_space"
-version = "2.14.0"
+version = "2.14.1"
 authors = ["Justin Kilpatrick <justin@althea.net>", "Michał Papierski <michal@papierski.net>"]
 repository = "https://github.com/althea-net/deep_space"
 description = "A highly portable, batteries included, transaction generation and key management library for CosmosSDK blockchains"

--- a/examples/signer.rs
+++ b/examples/signer.rs
@@ -3,8 +3,8 @@ use cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend;
 use deep_space::client::msgs::SECP256K1_PUBKEY_TYPE_URL;
 use deep_space::Fee;
 use deep_space::Msg;
-use deep_space::{CosmosPrivateKey, PrivateKey, PublicKey};
 use deep_space::{Coin, MessageArgs};
+use deep_space::{CosmosPrivateKey, PrivateKey, PublicKey};
 use std::fs::File;
 use std::io::Write;
 

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -1,0 +1,63 @@
+use super::PAGE;
+use crate::address::Address;
+use crate::client::types::BaseAccount;
+use crate::client::types::*;
+use crate::{client::Contact, error::CosmosGrpcError};
+use cosmos_sdk_proto::cosmos::auth::v1beta1::{
+    query_client::QueryClient as AuthQueryClient, QueryAccountRequest, QueryAccountsRequest,
+};
+use tonic::Code as GrpcCode;
+
+impl Contact {
+    /// Gets account info for the provided Cosmos account using the accounts endpoint
+    /// accounts do not have any info if they have no tokens or are otherwise never seen
+    /// before in this case we return the special error NoToken
+    pub async fn get_account_info(&self, address: Address) -> Result<BaseAccount, CosmosGrpcError> {
+        match self.get_account_vesting_info(address).await {
+            Ok(a) => Ok(a.get_base_account()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Gets account info for the provided Cosmos account using the accounts endpoint
+    /// accounts do not have any info if they have no tokens or are otherwise never seen
+    /// before in this case we return the special error NoToken
+    pub async fn get_account_vesting_info(
+        &self,
+        address: Address,
+    ) -> Result<AccountType, CosmosGrpcError> {
+        let mut agrpc = AuthQueryClient::connect(self.url.clone())
+            .await?
+            .accept_gzip();
+        let query = QueryAccountRequest {
+            address: address.to_bech32(&self.chain_prefix).unwrap(),
+        };
+        let res = agrpc.account(query).await;
+        match res {
+            Ok(account) => {
+                // null pointer if this fails to unwrap
+                let value = account.into_inner().account.unwrap();
+                AccountType::decode_from_any(value)
+            }
+            Err(e) => match e.code() {
+                GrpcCode::NotFound => Err(CosmosGrpcError::NoToken),
+                _ => Err(CosmosGrpcError::RequestError { error: e }),
+            },
+        }
+    }
+
+    /// Gets account info for every account on the chain, a large query
+    pub async fn get_all_accounts(&self) -> Result<Vec<AccountType>, CosmosGrpcError> {
+        let mut agrpc = AuthQueryClient::connect(self.url.clone())
+            .await?
+            .accept_gzip();
+        let query = QueryAccountsRequest { pagination: PAGE };
+        let res = agrpc.accounts(query).await?;
+        let mut accounts = Vec::new();
+        for value in res.into_inner().accounts {
+            accounts.push(AccountType::decode_from_any(value)?);
+        }
+
+        Ok(accounts)
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+pub mod auth;
 pub mod bank;
 pub mod distribution;
 pub mod get;
@@ -75,8 +76,6 @@ impl Contact {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::private_key::{CosmosPrivateKey, PrivateKey};
-    use crate::Coin;
 
     const TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -86,48 +85,19 @@ mod tests {
     /// to run the following command and copy a phrase so that you actually
     /// have some coins to send funds
     /// docker exec -it gravity_test_instance cat /validator-phrases
-    #[actix_rt::test]
     #[ignore]
+    #[actix_rt::test]
     async fn test_endpoints() {
         env_logger::init();
-        let key = CosmosPrivateKey::from_phrase("boost casual myth skin olympic sure apology creek theme conduct view panda board pride miss turkey lonely strategy panel mad blast panda work shuffle", "").unwrap();
-        let token_name = "ufootoken".to_string();
-        let contact = Contact::new("http://testnet2.althea.net:9090", TIMEOUT, "althea").unwrap();
-        let our_address = key.to_address(&contact.get_prefix()).unwrap();
-        let destination = "althea1ezyy5y8a4pzv9jgaeh4gd2c4kmhfn4pmpjc8np"
-            .parse()
-            .unwrap();
+        let contact = Contact::new("http://gravitychain.io:9090", TIMEOUT, "gravity").unwrap();
 
         let chain_status = contact.get_chain_status().await.unwrap();
         match chain_status {
             ChainStatus::Moving { block_height: _ } => {}
             ChainStatus::Syncing | ChainStatus::WaitingToStart => panic!("Chain not running"),
         }
-
         let _latest_block = contact.get_latest_block().await.unwrap();
-        let _account_info = contact.get_account_info(our_address).await.unwrap();
 
-        let balances = contact.get_balances(our_address).await.unwrap();
-        let mut ok = false;
-        for coin in balances {
-            if coin.denom == token_name {
-                ok = true
-            }
-        }
-        if !ok {
-            panic!(
-                "Could not find {} in the account of {}",
-                token_name, our_address
-            );
-        }
-
-        let send = Coin {
-            denom: token_name,
-            amount: 100u64.into(),
-        };
-        contact
-            .send_coins(send.clone(), Some(send), destination, Some(TIMEOUT), key)
-            .await
-            .unwrap();
+        let _ = contact.get_all_accounts().await.unwrap();
     }
 }

--- a/src/client/send.rs
+++ b/src/client/send.rs
@@ -143,7 +143,9 @@ impl Contact {
         let our_address = private_key.to_address(&self.chain_prefix).unwrap();
         let memo = memo.unwrap_or_else(|| MEMO.to_string());
 
-        let fee = self.get_fee_info(messages, fee_coin, private_key.clone()).await?;
+        let fee = self
+            .get_fee_info(messages, fee_coin, private_key.clone())
+            .await?;
 
         let args = self.get_message_args(our_address, fee).await?;
         trace!("got optional tx info");

--- a/src/error.rs
+++ b/src/error.rs
@@ -203,7 +203,7 @@ impl From<bech32::Error> for AddressError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ByteDecodeError {
     DecodeError(Utf8Error),
     ParseError(ParseIntError),
@@ -296,7 +296,7 @@ impl fmt::Display for PrivateKeyError {
             PrivateKeyError::HdWalletError(val) => write!(f, "{}", val),
             PrivateKeyError::InvalidMnemonic { error } => {
                 write!(f, "Failed to process mnemonic {:?}", error)
-            },
+            }
             PrivateKeyError::ZeroPrivateKey => write!(f, "PrivateKeyError Zero Private Key"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,9 @@ pub use coin::Coin;
 pub use coin::Fee;
 pub use mnemonic::Mnemonic;
 pub use msg::Msg;
-pub use private_key::MessageArgs;
-pub use private_key::{CosmosPrivateKey, PrivateKey};
 #[cfg(feature = "ethermint")]
 pub use private_key::EthermintPrivateKey;
+pub use private_key::MessageArgs;
+pub use private_key::{CosmosPrivateKey, PrivateKey};
 pub use public_key::PublicKey;
 pub use signature::Signature;

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -13,9 +13,13 @@ use std::str::FromStr;
 pub trait PublicKey {
     const DEFAULT_PREFIX: &'static str;
 
-    fn from_slice<T: Into<String>>(bytes: &[u8], prefix: T) -> Result<Self, PublicKeyError> where Self: Sized;
+    fn from_slice<T: Into<String>>(bytes: &[u8], prefix: T) -> Result<Self, PublicKeyError>
+    where
+        Self: Sized;
 
-    fn from_bytes<T: Into<String>>(bytes: [u8; 33], prefix: T) -> Result<Self, PublicKeyError> where Self: Sized;
+    fn from_bytes<T: Into<String>>(bytes: [u8; 33], prefix: T) -> Result<Self, PublicKeyError>
+    where
+        Self: Sized;
 
     fn as_bytes(&self) -> &[u8];
 
@@ -33,7 +37,9 @@ pub trait PublicKey {
 
     fn to_bech32<T: Into<String>>(&self, hrp: T) -> Result<String, PublicKeyError>;
 
-    fn from_bech32(s: String) -> Result<Self, PublicKeyError> where Self: Sized;
+    fn from_bech32(s: String) -> Result<Self, PublicKeyError>
+    where
+        Self: Sized;
 }
 /// Represents a public key of a given private key in the Cosmos Network.
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
@@ -54,10 +60,7 @@ impl PublicKey for CosmosPublicKey {
     }
 
     /// Create a public key using an array of bytes
-    fn from_bytes<T: Into<String>>(
-        bytes: [u8; 33],
-        prefix: T,
-    ) -> Result<Self, PublicKeyError> {
+    fn from_bytes<T: Into<String>>(bytes: [u8; 33], prefix: T) -> Result<Self, PublicKeyError> {
         Ok(CosmosPublicKey {
             bytes,
             prefix: ArrayString::new(&prefix.into())?,
@@ -159,10 +162,7 @@ impl PublicKey for EthermintPublicKey {
     }
 
     /// Create a public key using an array of bytes
-    fn from_bytes<T: Into<String>>(
-        bytes: [u8; 33],
-        prefix: T,
-    ) -> Result<Self, PublicKeyError> {
+    fn from_bytes<T: Into<String>>(bytes: [u8; 33], prefix: T) -> Result<Self, PublicKeyError> {
         Ok(EthermintPublicKey {
             bytes,
             prefix: ArrayString::new(&prefix.into())?,
@@ -187,7 +187,8 @@ impl PublicKey for EthermintPublicKey {
     }
 
     fn to_address(&self) -> Address {
-        self.to_address_with_prefix(&self.prefix.to_string()).unwrap()
+        self.to_address_with_prefix(&self.prefix.to_string())
+            .unwrap()
     }
 
     fn to_address_with_prefix(&self, prefix: &str) -> Result<Address, AddressError> {
@@ -227,7 +228,10 @@ impl PublicKey for EthermintPublicKey {
 }
 
 /// Create a public key using a slice of bytes
-fn from_slice<T: Into<String>, PK: PublicKey + Sized>(bytes: &[u8], prefix: T) -> Result<PK, PublicKeyError> {
+fn from_slice<T: Into<String>, PK: PublicKey + Sized>(
+    bytes: &[u8],
+    prefix: T,
+) -> Result<PK, PublicKeyError> {
     if bytes.len() != 33 {
         return Err(PublicKeyError::BytesDecodeErrorWrongLength);
     }
@@ -274,7 +278,10 @@ impl FromStr for CosmosPublicKey {
                     if bytes.len() == 33 {
                         let mut inner = [0; 33];
                         inner.copy_from_slice(&bytes[0..33]);
-                        Ok(PublicKey::from_bytes(inner, CosmosPublicKey::DEFAULT_PREFIX)?)
+                        Ok(PublicKey::from_bytes(
+                            inner,
+                            CosmosPublicKey::DEFAULT_PREFIX,
+                        )?)
                     } else {
                         Err(PublicKeyError::BytesDecodeErrorWrongLength)
                     }


### PR DESCRIPTION
This patch adds support for viewing vesting info for individual accounts as well as a new query that gets global vesting info across all accounts.