### PR TITLE
Add 32 byte DerivedAddress support

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -112,7 +112,7 @@ impl PublicKey for CosmosPublicKey {
         let ripemd160 = Ripemd::digest(&sha256);
         let mut bytes: [u8; 20] = Default::default();
         bytes.copy_from_slice(&ripemd160[..]);
-        Address::from_bytes(bytes, prefix)
+        Address::from_slice(&bytes, prefix)
     }
 
     /// Creates amino representation of a given public key.


### PR DESCRIPTION
With the addition of ICA and "derived" accounts in general, deep_space needs to support 32 byte Addresses.

Address is now an enum with the 20 byte variant (BaseAddress) and a new 30 byte variant (DerivedAddress).