### PR TITLE
Fix tx simulation in presence of a global fee

### DIFF
--- a/src/client/invariant.rs
+++ b/src/client/invariant.rs
@@ -41,7 +41,7 @@ impl Contact {
         };
         let msg = Msg::new(MSG_VERIFY_INVARIANT_TYPE_URL, verify);
         trace!("Submitting simulation");
-        self.simulate_tx(&[msg], private_key).await
+        self.simulate_tx(&[msg], None, private_key).await
     }
 
     /// A utility function which executes the specified invariant and returns the TxResponse if one is given


### PR DESCRIPTION
Althea L1 uses the x/evm module, which often requires the use of a minimum global fee. Transaction simulation completely broke because of this and led to even manually provided fee amounts to contact.send_message() to fail in get_fee_info() and submit an empty collection of fees. Adding an optional fee parameter to transaction submission fixes this in the case where the caller provides a fee value.