### PR TITLE
Make tonic ssl optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_space"
-version = "2.21.3"
+version = "2.22.0"
 authors = ["Justin Kilpatrick <justin@althea.net>", "Michał Papierski <michal@papierski.net>"]
 repository = "https://github.com/althea-net/deep_space"
 description = "A highly portable, batteries included, transaction generation and key management library for CosmosSDK blockchains"
@@ -18,22 +18,22 @@ serde_json = "1.0"
 serde_derive = "1.0"
 base64 = "0.21"
 unicode-normalization = {version = "0.1"}
-prost-types = "0.10"
-prost = "0.10"
+prost-types = "0.11"
+prost = "0.11"
 pbkdf2 = {version = "0.12"}
 hmac = {version = "0.12"}
 rand = {version = "0.8"}
 rust_decimal = "1.9"
 secp256k1 = {version = "0.27", features = ["global-context"]}
-tonic = {version = "0.7", features = ["compression"]}
+tonic = {version = "0.9", features = ["gzip"]}
 bytes = "1.0"
 log = "0.4"
 tokio = {version = "1", features=["time"]}
 clarity = {version = "1.2", optional = true}
 sha3 = {version = "0.10", optional = true}
 
-cosmos-sdk-proto = {package = "cosmos-sdk-proto-althea", version = "0.14"}
-althea_proto = {version="0.1", optional=true}
+cosmos-sdk-proto = {package = "cosmos-sdk-proto-althea", version = "0.15"}
+althea_proto = {version="0.2", optional=true}
 
 [dev-dependencies]
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_space"
-version = "2.21.2"
+version = "2.21.3"
 authors = ["Justin Kilpatrick <justin@althea.net>", "Michał Papierski <michal@papierski.net>"]
 repository = "https://github.com/althea-net/deep_space"
 description = "A highly portable, batteries included, transaction generation and key management library for CosmosSDK blockchains"
@@ -25,7 +25,7 @@ hmac = {version = "0.12"}
 rand = {version = "0.8"}
 rust_decimal = "1.9"
 secp256k1 = {version = "0.27", features = ["global-context"]}
-tonic = {version = "0.7", features = ["compression", "tls", "tls-roots"]}
+tonic = {version = "0.7", features = ["compression"]}
 bytes = "1.0"
 log = "0.4"
 tokio = {version = "1", features=["time"]}
@@ -42,5 +42,7 @@ actix-rt = "2.2"
 
 
 [features]
+default = ["ssl"]
 ethermint = ["clarity", "sha3"]
 althea = ["ethermint", "dep:althea_proto"]
+ssl = ["tonic/tls", "tonic/tls-roots"]

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -26,9 +26,7 @@ impl Contact {
         &self,
         address: Address,
     ) -> Result<AccountType, CosmosGrpcError> {
-        let mut agrpc = AuthQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut agrpc = AuthQueryClient::connect(self.url.clone()).await?;
         let query = QueryAccountRequest {
             address: address.to_bech32(&self.chain_prefix).unwrap(),
         };
@@ -48,9 +46,7 @@ impl Contact {
 
     /// Gets account info for every account on the chain, a large query
     pub async fn get_all_accounts(&self) -> Result<Vec<AccountType>, CosmosGrpcError> {
-        let mut agrpc = AuthQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut agrpc = AuthQueryClient::connect(self.url.clone()).await?;
         let query = QueryAccountsRequest { pagination: PAGE };
         let res = agrpc.accounts(query).await?;
         let mut accounts = Vec::new();

--- a/src/client/bank/mod.rs
+++ b/src/client/bank/mod.rs
@@ -13,9 +13,7 @@ use cosmos_sdk_proto::cosmos::bank::v1beta1::{QueryAllBalancesRequest, QueryBala
 impl Contact {
     /// gets the total supply of all coins on chain
     pub async fn query_total_supply(&self) -> Result<Vec<Coin>, CosmosGrpcError> {
-        let mut grpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .total_supply(QueryTotalSupplyRequest { pagination: PAGE })
             .await?
@@ -29,9 +27,7 @@ impl Contact {
 
     /// gets the supply of an individual token
     pub async fn query_supply_of(&self, denom: String) -> Result<Option<Coin>, CosmosGrpcError> {
-        let mut grpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .supply_of(QuerySupplyOfRequest { denom })
             .await?
@@ -44,9 +40,7 @@ impl Contact {
 
     /// Gets the denom metadata for every token type on the chain
     pub async fn get_all_denoms_metadata(&self) -> Result<Vec<Metadata>, CosmosGrpcError> {
-        let mut grpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .denoms_metadata(QueryDenomsMetadataRequest { pagination: PAGE })
             .await?
@@ -59,9 +53,7 @@ impl Contact {
         &self,
         denom: String,
     ) -> Result<Option<Metadata>, CosmosGrpcError> {
-        let mut grpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .denom_metadata(QueryDenomMetadataRequest { denom })
             .await?
@@ -71,9 +63,7 @@ impl Contact {
 
     /// Gets the coin balances for an individual account
     pub async fn get_balances(&self, address: Address) -> Result<Vec<Coin>, CosmosGrpcError> {
-        let mut bankrpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut bankrpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = bankrpc
             .all_balances(QueryAllBalancesRequest {
                 // chain prefix is validated as part of this client, so this can't
@@ -97,9 +87,7 @@ impl Contact {
         address: Address,
         denom: String,
     ) -> Result<Option<Coin>, CosmosGrpcError> {
-        let mut bankrpc = BankQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut bankrpc = BankQueryClient::connect(self.url.clone()).await?;
         let res = bankrpc
             .balance(QueryBalanceRequest {
                 // chain prefix is validated as part of this client, so this can't

--- a/src/client/distribution/mod.rs
+++ b/src/client/distribution/mod.rs
@@ -38,9 +38,7 @@ impl Contact {
     /// are in DecCoins for precision, for the sake of ease of use this endpoint converts them
     /// into their normal form, for easy comparison against any other coin or amount.
     pub async fn query_community_pool(&self) -> Result<Vec<Coin>, CosmosGrpcError> {
-        let mut grpc = DistQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = DistQueryClient::connect(self.url.clone()).await?;
         let res = grpc.community_pool(QueryCommunityPoolRequest {}).await?;
         let val = res.into_inner().pool;
         let mut res = Vec::new();
@@ -62,9 +60,7 @@ impl Contact {
         &self,
         validator_address: impl ToString,
     ) -> Result<Vec<ValidatorSlashEvent>, CosmosGrpcError> {
-        let mut grpc = DistQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = DistQueryClient::connect(self.url.clone()).await?;
         let current_block = self.get_chain_status().await?;
         let current_block = match current_block {
             ChainStatus::Moving { block_height } => block_height,
@@ -107,9 +103,7 @@ impl Contact {
         &self,
         delegator_address: Address,
     ) -> Result<Vec<String>, CosmosGrpcError> {
-        let mut grpc = DistQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = DistQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .delegator_validators(QueryDelegatorValidatorsRequest {
                 delegator_address: delegator_address.to_string(),
@@ -125,9 +119,7 @@ impl Contact {
         delegator_address: Address,
         validator_address: Address,
     ) -> Result<Vec<DecCoin>, CosmosGrpcError> {
-        let mut grpc = DistQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = DistQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .delegation_rewards(QueryDelegationRewardsRequest {
                 delegator_address: delegator_address.to_string(),
@@ -144,9 +136,7 @@ impl Contact {
         &self,
         delegator_address: Address,
     ) -> Result<QueryDelegationTotalRewardsResponse, CosmosGrpcError> {
-        let mut grpc = DistQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = DistQueryClient::connect(self.url.clone()).await?;
         let res = grpc
             .delegation_total_rewards(QueryDelegationTotalRewardsRequest {
                 delegator_address: delegator_address.to_string(),

--- a/src/client/get.rs
+++ b/src/client/get.rs
@@ -22,9 +22,7 @@ impl Contact {
     /// Gets the current chain status, returns an enum taking into account the various possible states
     /// of the chain and the requesting full node. In the common case this provides the block number
     pub async fn get_chain_status(&self) -> Result<ChainStatus, CosmosGrpcError> {
-        let mut grpc = TendermintServiceClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = TendermintServiceClient::connect(self.url.clone()).await?;
         let syncing = grpc.get_syncing(GetSyncingRequest {}).await?.into_inner();
 
         if syncing.syncing {
@@ -61,9 +59,7 @@ impl Contact {
     /// Gets the latest block from the node, taking into account the possibility that the chain is halted
     /// and also the possibility that the node is syncing
     pub async fn get_latest_block(&self) -> Result<LatestBlock, CosmosGrpcError> {
-        let mut grpc = TendermintServiceClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = TendermintServiceClient::connect(self.url.clone()).await?;
         let syncing = grpc
             .get_syncing(GetSyncingRequest {})
             .await?
@@ -86,9 +82,7 @@ impl Contact {
 
     /// Gets the specified block from the node, returns none if no block is available
     pub async fn get_block(&self, block: u64) -> Result<Option<Block>, CosmosGrpcError> {
-        let mut grpc = TendermintServiceClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = TendermintServiceClient::connect(self.url.clone()).await?;
 
         let block = grpc
             .get_block_by_height(GetBlockByHeightRequest {
@@ -108,9 +102,7 @@ impl Contact {
         start: u64,
         end: u64,
     ) -> Result<Vec<Option<Block>>, CosmosGrpcError> {
-        let mut grpc = TendermintServiceClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = TendermintServiceClient::connect(self.url.clone()).await?;
 
         let mut result = Vec::new();
         for i in start..end {
@@ -154,9 +146,7 @@ impl Contact {
         subspace: impl ToString,
         key: impl ToString,
     ) -> Result<QueryParamsResponse, CosmosGrpcError> {
-        let mut grpc = ParamsQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = ParamsQueryClient::connect(self.url.clone()).await?;
         Ok(grpc
             .params(QueryParamsRequest {
                 subspace: subspace.to_string(),
@@ -168,9 +158,7 @@ impl Contact {
 
     // Gets a transaction using it's hash value, TODO should fail if the transaction isn't found
     pub async fn get_tx_by_hash(&self, txhash: String) -> Result<GetTxResponse, CosmosGrpcError> {
-        let mut txrpc = TxServiceClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut txrpc = TxServiceClient::connect(self.url.clone()).await?;
         let res = txrpc
             .get_tx(GetTxRequest { hash: txhash })
             .await?

--- a/src/client/gov/mod.rs
+++ b/src/client/gov/mod.rs
@@ -33,9 +33,7 @@ impl Contact {
         &self,
         filters: QueryProposalsRequest,
     ) -> Result<QueryProposalsResponse, CosmosGrpcError> {
-        let mut grpc = GovQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = GovQueryClient::connect(self.url.clone()).await?;
         let res = grpc.proposals(filters).await?.into_inner();
         Ok(res)
     }

--- a/src/client/send.rs
+++ b/src/client/send.rs
@@ -83,9 +83,7 @@ impl Contact {
         msg: Vec<u8>,
         mode: BroadcastMode,
     ) -> Result<TxResponse, CosmosGrpcError> {
-        let mut txrpc = TxServiceClient::connect(self.get_url())
-            .await?
-            .accept_gzip();
+        let mut txrpc = TxServiceClient::connect(self.get_url()).await?;
         let response = txrpc
             .broadcast_tx(BroadcastTxRequest {
                 tx_bytes: msg,
@@ -246,9 +244,7 @@ impl Contact {
     ) -> Result<SimulateResponse, CosmosGrpcError> {
         let our_address = private_key.to_address(&self.chain_prefix).unwrap();
         let fee_amount = fee_amount.unwrap_or_default();
-        let mut txrpc = TxServiceClient::connect(self.get_url())
-            .await?
-            .accept_gzip();
+        let mut txrpc = TxServiceClient::connect(self.get_url()).await?;
 
         let fee_obj = Fee {
             amount: fee_amount.to_vec(),

--- a/src/client/staking/mod.rs
+++ b/src/client/staking/mod.rs
@@ -28,9 +28,7 @@ impl Contact {
         &self,
         filters: QueryValidatorsRequest,
     ) -> Result<Vec<Validator>, CosmosGrpcError> {
-        let mut grpc = StakingQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = StakingQueryClient::connect(self.url.clone()).await?;
 
         let res = grpc.validators(filters).await?.into_inner().validators;
         Ok(res)
@@ -50,9 +48,7 @@ impl Contact {
         &self,
         validator: Address,
     ) -> Result<Vec<DelegationResponse>, CosmosGrpcError> {
-        let mut grpc = StakingQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = StakingQueryClient::connect(self.url.clone()).await?;
 
         let res = grpc
             .validator_delegations(QueryValidatorDelegationsRequest {
@@ -71,9 +67,7 @@ impl Contact {
         validator: Address,
         delegator: Address,
     ) -> Result<Option<DelegationResponse>, CosmosGrpcError> {
-        let mut grpc = StakingQueryClient::connect(self.url.clone())
-            .await?
-            .accept_gzip();
+        let mut grpc = StakingQueryClient::connect(self.url.clone()).await?;
 
         let res = grpc
             .delegation(QueryDelegationRequest {


### PR DESCRIPTION
This patch makes the tonic ssl flag an optional, but default dependency.

This should have no effect on existing users but will allow those using the no-default-features flag to avoid pulling in the Ring crate. The Ring crate does not support cpu mips and mipsel cpu architectures which causes compilation to fail.

Obviously mips and mipsel architectures will need to make unencrypted grpc connections, which come with their own problems. But this change will at least make it possible to compile.